### PR TITLE
Resolved byte object vs string conflict

### DIFF
--- a/FSM_Learner_Module/Dummy_UE_Device/device.py
+++ b/FSM_Learner_Module/Dummy_UE_Device/device.py
@@ -36,7 +36,7 @@ rrc_con_request = False
 state = deregistered  # initial state
 
 while 1:
-    cmd = client.recv(1024).strip()
+    cmd = client.recv(1024).decode('utf-8').strip()
     print("Command recevied: " +cmd)
 
     # print cmd
@@ -546,4 +546,4 @@ while 1:
 
 
     print "CMD = ", cmd, "-> RESPONSE = ", response
-    client.sendall(response)
+     client.sendall(response.encode('utf-8'))


### PR DESCRIPTION
Converted cmd from byte object to its string representation so that it can be used in equality checking.
Also, converted the response from string to byte object before sending over socket medium.